### PR TITLE
Removes duplicate declaration of some variables in ItemComponent

### DIFF
--- a/Barotrauma/BarotraumaShared/Source/Items/Components/ItemComponent.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/ItemComponent.cs
@@ -545,7 +545,6 @@ namespace Barotrauma.Items.Components
                 GameAnalyticsManager.AddErrorEventOnce("ItemComponent.DegreeOfSuccess:CharacterNull", GameAnalyticsSDK.Net.EGAErrorSeverity.Error, errorMsg);
                 return 0.0f;
             }
-            float average = skillSuccessSum / requiredSkills.Count;
 
             float skillSuccessSum = 0.0f;
             for (int i = 0; i < requiredSkills.Count; i++)


### PR DESCRIPTION
When I'm compiling the `dev` branch for a Debian server, I was getting these errors upon compilation:

```
(CoreCompile target) ->
  /build/Barotrauma/BarotraumaShared/Source/Items/Components/ItemComponent.cs(548,29): error CS0841: Cannot use local variable 'skillSuccessSum' before it is declared [/build/Barotrauma/BarotraumaServer/Server.csproj]
  /build/Barotrauma/BarotraumaShared/Source/Items/Components/ItemComponent.cs(556,19): error CS0128: A local variable or function named 'average' is already defined in this scope [/build/Barotrauma/BarotraumaServer/Server.csproj]
```

I removed the duplicated code, updated the server and it works.